### PR TITLE
Removed default key pair name

### DIFF
--- a/aws
+++ b/aws
@@ -224,7 +224,7 @@ $sdb_version = "2009-04-15";
 								      [MinCount => $min, MaxCount => $max];
 								  }],
 								 ["group g", SecurityGroupN, "default"],
-								 ["key k", KeyName, "default"],
+								 ["key k", KeyName],
 								 ["user-data d", UserData, undef, sub {encode_base64($_[0], "")}],
 								 ["user-data-file f", UserData, undef, sub {encode_base64(load_file($_[0]))}],
 								 ["a", AddressingType],

--- a/index.html
+++ b/index.html
@@ -504,7 +504,7 @@ Use "aws COMMAND -h" to see the options available for each command.  For example
 <blockquote style="font: normal 8pt monospace">
 $ ./aws run -h
 <br>$ ./aws run -h
-Usage: aws run-instance run [ImageId (ami-23b6534a)] [-i InstanceType (ml.small)] [-a AddressingType (public)] [-n MinCount (1)] [-n MaxCount (1)] [-g SecurityGroup... (default)] [-k KeyName (default)] [-d UserData] [-f UserData]
+Usage: aws run-instance run [ImageId (ami-23b6534a)] [-i InstanceType (ml.small)] [-a AddressingType (public)] [-n MinCount (1)] [-n MaxCount (1)] [-g SecurityGroup... (default)] [-k KeyName] [-d UserData] [-f UserData]
 </blockquote>
 Here we see that the <code>run-instance</code> command takes an image id, an instance type, an addressing type, a count of servers, security groups, a key name, and user data.  The defaults are specified in parentheses.
 <p>


### PR DESCRIPTION
Hi Tim, 

Since the change I was requesting was such a trivial one, I figured I could handle it :)

I removed the "default" key pair name for aws run and updated index.html to reflect the change.

Thanks, 
Lou Zell
