### PR TITLE
S3 certificate error with bucket names containing a dot.

### DIFF
--- a/aws
+++ b/aws
@@ -621,7 +621,7 @@ unshift @ARGV, $1 if $0 =~ /^(?:.*[\\\/])?(?:(?:ec2|s3|sqs|sdb)-?)?(.+?)(?:\..+)
     my(%meta);
     @meta{qw(1 cmd0 curl_options cut d delimeter dump_xml exec expire_time fail h help
 	     insecure insecure_signing insecure_aws insecureaws install l limit_rate link
-	     max_time marker md5 prefix private progress public queue r region request requester retry
+	     max_time marker md5 no_vhost prefix private progress public queue r region request requester retry
 	     s3host sanity_check secrets_file set_acl sign silent simple t v verbose vv vvv wait xml)} = undef;
 
     my @awsrc = "";
@@ -1828,7 +1828,7 @@ sub s3
     }
 
     my($vhost, $vname) = ($s3host, $uname);
-    if (!$no_vhost)
+    if ($no_vhost)
     {
 	($vhost, $vname) = ($dns_alias? $1: "$1.$vhost", $2) if $uname =~ /^([0-9a-z][\.\-0-9a-z]{1,61}[0-9a-z])(?:\/(.*))?$/;
     }


### PR DESCRIPTION
s3 commands from aws failed on AWS Linux, running it in verbose mode the following curl problem occurred:
 SSL: certificate subject name '*.s3.amazonaws.com' does not match target host name 'mybucket.mydomain.com.s3.amazonaws.com'

The problem caused by the no_vhost variable which was undef by default, at line 1831 the if(!$no_vhost) was true and the vhost has been redifined.
