### PR TITLE
Fix yaml support

### DIFF
--- a/aws
+++ b/aws
@@ -1892,7 +1892,7 @@ sub xml2yaml {
   $result =~ s#> #>\n#g;                            # remove all '\n's
   $result =~ s#</.*>##g;                            # remove closing tags
   $result =~ s#<([a-z0-9:]*).*>#$rubySymbol\1: #gi; # opening tags -> symbols
-  $result =~ s#($rubySymbol[^:]+): (.+)#\1: \2#g;   # opening tags -> symbols
+  $result =~ s#($rubySymbol[^:]+): (.+)#\1: "\2"#g; # opening tags -> symbols
   $result =~ s#:?(.*)/:#\1:#g;                      # empty values
   $result =~ s#:?(item|bucket|member): #- #gi;      # array items
   $result =~ s#\t#  #g;                             # tabs -> spaces


### PR DESCRIPTION
yaml support: Remove the prefix > in data.

The prefix > is used to preserve new lines. It works fine
with previous implementation of Ruby/Yaml, but it doesn't
work anymore. When removing this prefix, there may be a
problem with multiple-output from the aws.pl (though I
have never seen such case.)
