### PR TITLE
Add support for --simple output format to ec2 describe-keypairs command

### DIFF
--- a/aws
+++ b/aws
@@ -1574,7 +1574,7 @@ if (!$cmd_data)
     {
 	print ary2tab(xml2ary(GetQueueAttributesResult, $result, {key => Name, value => Value}), {title => "Attributes", empty => "no attributes\n"});
     }
-    elsif ($result =~ /<DescribeTagsResponse/ && $simple)
+    elsif ($result =~ /<DescribeTagsResponse|<DescribeKeyPairsResponse/ && $simple)
     {
 	while ($result =~ /<item>(.*?)<\/item>/sg)
 	{


### PR DESCRIPTION
I needed to fetch the fingerprint of a specific key easily in a script, so the --simple output format was ideal... but apparently isn't supported yet. I believe this small change should fix that.
