### PR TITLE
#39: improve authinfo/netrc parsing and support --netrc-machine=K (default=AWS)

### DIFF
--- a/aws
+++ b/aws
@@ -983,7 +983,7 @@ unless ($awskey && $secret)
                foreach my $line (split "\n", $secret_data)
                {
                    my @tok;
-                   # gratefully stolen from Net::Netrc
+                   # modeled after Net::Netrc (Perl Artistic License: This program is free software; you can redistribute it and/or modify it under the same terms as Perl itself.(
                    while (length $line &&
                           $line =~ s/^("((?:[^"]+|\\.)*)"|((?:[^\\\s]+|\\.)*))\s*//)
                    {


### PR DESCRIPTION
This has a better parser (stolen from Net::Netrc) and lets the user specify what "machine K" line to use.

I'd like to document the --netrc-machine option and the netrc format but I don't see a place in the code.  Should I use the wiki?
