### PR TITLE
Undo change to curl option from '--dump-header -' to '--include';

### DIFF
--- a/aws
+++ b/aws
@@ -2669,7 +2669,7 @@ sub s3
     my($accept);
     $accept = "--header \"Expect: \"" if ($verb eq PUT || $verb eq POST) && (-s $file) < 10_000;
 
-    my $cmd = qq[$curl $curl_options $insecureaws $accept $header --request $verb --include $content --location @{[cq($url)]}];
+    my $cmd = qq[$curl $curl_options $insecureaws $accept $header --request $verb --dump-header - $content --location @{[cq($url)]}];
     print STDERR "$cmd\n" if $v;
     my $item = qx[$cmd];
     exit $? >> 8 if $? && $fail;


### PR DESCRIPTION
Commit b65b26 from 7Apr2013 includes (among other things) a change in four places to the an option passed to curl.  '--dump-header -' is replaced by '--include' (motivation unknown).  This works okay the first three places because no file is being written by curl, but the fourth change breaks file downloads by prepending HTTP headers to the file.

This trivial patch changes the option back to '--dump header -'.
