### PR TITLE
Any reason why $HOME can't be used as the first choice in get_home_directory?

### DIFF
--- a/aws
+++ b/aws
@@ -2930,7 +2930,7 @@ sub guess_is_unix
 
 sub get_home_directory
 {
-    return "$ENV{HOMEDRIVE}$ENV{HOMEPATH}" || "C:" if !$isUnix;
+    return $ENV{HOME} || "$ENV{HOMEDRIVE}$ENV{HOMEPATH}" || "C:" if !$isUnix;
     return (getpwuid($<))[7];
 }
 


### PR DESCRIPTION
I'm on Cygwin, and `get_home_directory` returns my Windows path (`C:\Users\readparse`) instead of my actual home directory (`/home/readparse`), which is correct in `$HOME`.  I would have expected `$HOME` to be the default, actually.  Perhaps there's a reason why it's not.   

Anyway, if you're open to it, I propose this simple patch.  Thanks for this project.  It's a great tool.
