### PR TITLE
Fix BlockDeviceMapping.N.NoDevice so that it is a non-value item ...

### DIFF
--- a/aws
+++ b/aws
@@ -3268,7 +3268,7 @@ sub parse_block_device_mapping
     push @result, "BlockDeviceMapping.N.DeviceName" => $dev;
     if ($vol eq "none")
     {
-	push @result, "BlockDeviceMapping.N.NoDevice" => "true";
+	push @result, "BlockDeviceMapping.N.NoDevice" => undef;   # no "true" - it's a non-value item.
     }
     elsif ($vol =~ /^ephemeral/)
     {


### PR DESCRIPTION
...as per the API spec.  Right now passing a -b /dev/foo=none causes a "invalid message" error; this fixes it.
Tested with the "none" block-device-mapping both first and last of two.
