### PR TITLE
S3 Bucket names with '.' not eligible for vhost treatment 

### DIFF
--- a/aws
+++ b/aws
@@ -1178,7 +1178,7 @@ unless ($awskey && $secret)
 
            # handle authinfo/netrc format
            if ($secret_data =~ /^\s*
-	       machine\s+AWS\s+.*?
+	       machine\s+(\S+)\s+.*?
 	       login\s+(\S+)\s+.*?
 	       password\s+(\S+)\s+.*?
 	       (\s+session\s+(\S+?))?/xm)


### PR DESCRIPTION
...since they don't match match the *.s3.amazonaws.com cert.
Most recent Openssl rejects such matches outright and curl --insecure does not seem to be able to override it.
Also fix .netrc file handling.
