### PR TITLE
route53: Fix #yaml output of #lrrs action (continued)

### DIFF
--- a/aws
+++ b/aws
@@ -2653,7 +2653,7 @@ sub xml2yaml {
 	$result =~ s#<([a-z0-9:]*).*>#$rubySymbol\1: #gi; # opening tags -> symbols
 	$result =~ s#($rubySymbol[^:]+): (.+)#\1: "\2"#g; # opening tags -> symbols
 	$result =~ s#:?(.*)/:#\1:#g;                      # empty values
-	$result =~ s#:?(item|bucket|member|ResourceRecordSet|HostedZone): #- #gi;
+	$result =~ s#:?(item|bucket|member|ResourceRecordSet|HostedZone|ResourceRecord): #- #gi;
 	                                                  # array items
 	$result =~ s#\t#  #g;                             # tabs -> spaces
 	$result =~ s#^[ :]*\n##mg;                        # remove all empty lines


### PR DESCRIPTION
# ResourceRecord is used to indicate an item of array.

It should be replaced by a dash (-)
