### PR TITLE
Add RDS support

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-"aws" is a command line program that accesses Amazon Web Services: EC2, S3, SQS, SDB, ELB, IAM, EBN
+"aws" is a command line program that accesses Amazon Web Services: EC2, S3, SQS, SDB, ELB, IAM, EBN, RDS
 
 To run "aws", all you need is a single file!
 

--- a/aws
+++ b/aws
@@ -344,6 +344,30 @@ $rds_version = "2013-09-09";
     # Parameter names are the same as RDS CLI documentation, with some additions.
 
     ### Database Instances ###
+
+    # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html
+    # http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-ModifyDBInstance.html
+    ["rds", "modify-db-instance mdb", ModifyDBInstance, [
+     ["", DBInstanceIdentifier],
+     ["allocated-storage s", AllocatedStorage],
+     ["allow-major-version-upgrade", AllowMajorVersionUpgrade],
+     ["apply-immediately", ApplyImmediately],
+     ["auto-minor-version-upgrade au", AutoMinorVersionUpgrade],
+     ["backup-retention-period r", BackupRetentionPeriod],
+     ["db-instance-class c", DBInstanceClass],
+     ["db-parameter-group-name g", DBParameterGroupName],
+     ["db-security-groups a", "DBSecurityGroups.memberN"],
+     ["engine-version v", EngineVersion],
+     ["iops", Iops],
+     ["master-user-password p", MasterUserPassword],
+     ["multi-az m", MultiAZ],
+     ["new-db-instance-identifier n", NewDBInstanceIdentifier],
+     ["option-group og", OptionGroupName],
+     ["preferred-backup-window b", PreferredBackupWindow],
+     ["preferred-maintenance-window w", PreferredMaintenanceWindow],
+     ["vpc-security-group-ids sg", "VpcSecurityGroupIds.memberN"]
+    ]],
+      
     # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html
     # http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-DeleteDBInstance.html
     ["rds", "delete-db-instance deldb", DeleteDBInstance, [
@@ -357,14 +381,33 @@ $rds_version = "2013-09-09";
      ["", ResourceName],
      ["tag", undef, undef, \&parse_tags_member]
     ]],
+
+    # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
+    # http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-DescribeDBInstances.html
+    ["rds", "describe-db-instances ddb", DescribeDBInstances, [
+     ["", DBInstanceIdentifier],
+     ["marker", Marker],
+     ["max-records m", MaxRecords]
+    ]],
     
     ### Database Snapshots and Point-In-Time Recovery ###
+    
     # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBSnapshot.html
     # http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-CreateDBSnapshot.html
     ["rds", "create-db-snapshot cdbsnap", CreateDBSnapshot, [
      ["", DBInstanceIdentifier],
      ["db-snapshot-identifier s snapshot", DBSnapshotIdentifier],
      ["tag", undef, undef, \&parse_tags_member]
+    ]],
+ 
+    # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBSnapshots.html
+    # http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-DescribeDBSnapshots.html
+    ["rds", "describe-db-snapshots ddbsnap", DescribeDBSnapshots, [
+     ["db-instance-identifier i", DBInstanceIdentifier],
+     ["db-snapshot-identifier s snapshot", DBSnapshotIdentifier],
+     ["marker", Marker],
+     ["max-records m", MaxRecords],
+     ["snapshot-type t", SnapshotType]
     ]],
  
     # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CopyDBSnapshot.html
@@ -377,7 +420,7 @@ $rds_version = "2013-09-09";
     
     # http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html
     # http://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-RestoreDBInstanceFromDBSnapshot.html
-    ["rds", "restore-db-instance-from-db-snapshot restoredb", RestoreDBInstanceFromDBSnapshot, [
+    ["rds", "restore-db-instance-from-db-snapshot rdb", RestoreDBInstanceFromDBSnapshot, [
      ["", DBInstanceIdentifier],
      ["db-snapshot-identifier s snapshot", DBSnapshotIdentifier],
      ["auto-minor-version-upgrade au", AutoMinorVersionUpgrade],
@@ -2254,6 +2297,72 @@ if (!$cmd_data)
 	    $result = qx[$0 --cmd0 --xml --region=$region describe-instances @instanceId];
 	}
     }
+    elsif ($result =~ /<CreateDBSnapshotResponse|<DeleteDBSnapshotResponse|<CopyDBSnapshotResponse/ && ($simple || $wait))
+    {
+	#<CreateDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+	#	<CreateDBSnapshotResult>
+	#		<DBSnapshot>
+	#			<Port>3306</Port>
+	#			<OptionGroupName>default:mysql-5-1</OptionGroupName>
+	#			<Engine>mysql</Engine>
+	#			<Status>creating</Status>
+	#			<SnapshotType>manual</SnapshotType>
+	#			<LicenseModel>general-public-license</LicenseModel>
+	#			<DBInstanceIdentifier>dbinstance</DBInstanceIdentifier>
+	#			<EngineVersion>5.1.69</EngineVersion>
+	#			<DBSnapshotIdentifier>asnapshot</DBSnapshotIdentifier>
+	#			<VpcId>vpc-30zzzzz</VpcId>
+	#			<AvailabilityZone>ap-southeast-2b</AvailabilityZone>
+	#			<InstanceCreateTime>2014-07-16T05:27:55.909Z</InstanceCreateTime>
+	#			<PercentProgress>0</PercentProgress>
+	#			<AllocatedStorage>5</AllocatedStorage>
+	#			<MasterUsername>user</MasterUsername>
+	#		</DBSnapshot>
+	#	</CreateDBSnapshotResult>
+	#	<ResponseMetadata>
+	#		<RequestId>2f1b87fa-12ed-11e4-be67-5b99b2d10c58</RequestId>
+	#	</ResponseMetadata>
+	#</CreateDBSnapshotResponse>
+	
+	for (;;)
+	{
+	    my($instanceId) = $result =~ /<DBInstanceIdentifier>(.*?)<\/DBInstanceIdentifier>/s;
+	    my($snapshotId) = $result =~ /<DBSnapshotIdentifier>(.*?)<\/DBSnapshotIdentifier>/s;
+	    my($progress) = $result =~ /<PercentProgress>(.*?)<\/PercentProgress>/s;
+	    my($status) = $result =~ /<Status>(.*?)<\/Status>/s;
+	    
+	    my($pending) += $status eq "creating" || $status eq "deleting";
+	    
+	    print "$instanceId\t$snapshotId\t$status\t$progress\n";
+    
+	    last unless $wait && $pending;
+    
+	    sleep $wait;
+	    $result = qx[$0 --cmd0 --xml --region=$region describe-db-snapshots -s $snapshotId];
+	}
+    }
+   elsif ($result =~ /<RestoreDBInstanceFromDBSnapshotResponse|<DeleteDBInstanceResponse|<ModifyDBInstanceResponse/ && ($simple || $wait))
+    {
+	# The current status of the instance.
+	# Valid values: available | backing-up | creating | deleted | deleting | failed | incompatible-restore |
+	# 		incompatible-parameters | modifying | rebooting | resetting-master-credentials | storage-full
+	for (;;)
+	{
+	    my($instanceId) = $result =~ /<DBInstanceIdentifier>(.*?)<\/DBInstanceIdentifier>/s;
+	    my($zone) = $result =~ /<AvailabilityZone>(.*?)<\/AvailabilityZone>/s;	# Zone is not available for RestoreDBInstanceFromDBSnapshotResponse
+	    my($engine) = $result =~ /<Engine>(.*?)<\/Engine>/s;
+	    my($status) = $result =~ /<DBInstanceStatus>(.*?)<\/DBInstanceStatus>/s;
+	    
+	    my($pending) += $status ne "available";
+	    
+	    print "$instanceId\t$engine\t$status\t$zone\n";
+    
+	    last unless $wait && $pending;
+    
+	    sleep $wait;
+	    $result = qx[$0 --cmd0 --xml --region=$region describe-db-instances $instanceId];
+	}
+    }     
     elsif ($result =~ /<ListQueuesResult/)
     {
 	if ($simple)
@@ -2404,6 +2513,12 @@ if (!$cmd_data)
     }
     else
     {
+	# If there is an error response and we haven't yet set an error return, do it now
+	if ( $result =~ /<ErrorResponse/ && !$ExitCode)
+	{
+	    $ExitCode = 1;
+	}
+	
 	print xml2tab($result) || xmlpp($result);
     }
 
@@ -3547,7 +3662,6 @@ sub parse_tags_member
     my($key, $value) = split(/=/, $_[0], 2);
     ["Tags.member.N.Key" => $key, "Tags.member.N.Value" => $value];
 }
-
 
 sub cq
 {


### PR DESCRIPTION
RDS support is by no means complete but sufficient exists to hibernate an RDS instance.

Hibernate in this case means to stop an RDS instance and then restart it
later and have the new instance be identical to the original. Can mean
big savings in aws charges. e.g. stop a db at 7pm in the evening and
then restart it at 7am in the morning - halves your costs.

See Wiki for example usage - RDS Example - stop-db.pl and start-db.pl.
