### PR TITLE
update ELB API version to 2011-11-15

### DIFF
--- a/aws
+++ b/aws
@@ -21,7 +21,7 @@ require v5.10;
 
 $ec2_version = "2013-10-15";
 $sqs_version = "2012-11-05";
-$elb_version = "2010-07-01";
+$elb_version = "2011-11-15";
 $sdb_version = "2009-04-15";
 $iam_version = "2010-05-08";
 $sts_version = "2011-06-15";


### PR DESCRIPTION
i'm not 100% sure how i should be doing this, but i got errors when using timkay/aws against our ELBs, and found that updating the API version made my errors go away.

is there more testing i can/should do, or anything else? i find this really useful but a central use case is managing ELBs so i'd love to contribute to making that work great. thanks!