### PR TITLE
Needs MIME::Base64 to support userdata

### DIFF
--- a/aws
+++ b/aws
@@ -32,6 +32,7 @@ $cfn_version = "2010-05-15";
 $rds_version = "2013-09-09";
 
 use Digest::SHA qw(hmac_sha1_base64 sha256_hex hmac_sha256 hmac_sha256_hex hmac_sha256_base64);
+use MIME::Base64 qw(encode_base64);
 
 #
 # Need to implement:


### PR DESCRIPTION
It looks like function from that module was used for UserData encoding but was use statement is missing. Adding it fixes the problem.