### PR TITLE
xml2yaml: fix a problem with trailing spaces

### DIFF
--- a/aws
+++ b/aws
@@ -2897,7 +2897,8 @@ sub xml2yaml {
 
     $rubySymbol = ":" if $ruby;
 
-    $result =~ s#\n# #g;
+  $result =~ s#> +#>#g;                             # remove trailing spaces after >
+  $result =~ s#\n# #g;                              # replace all \n by a single space
 	$result =~ s#> #>\n#g;                            # remove all '\n's
 	$result =~ s#</.*>##g;                            # remove closing tags
 	$result =~ s#<([a-z0-9:]*).*>#$rubySymbol\1: #gi; # opening tags -> symbols


### PR DESCRIPTION
The trailing spaces from the input should be removed; otherwise,
it will break the YAML output (invalid syntax issue).

Trailing spaces exist when users enter them in tag, name, ... fields.
Removing them means the original value and the result value are
different. There is no easy way to get rid of this problem!