### PR TITLE
Add no-sanity-check flag

### DIFF
--- a/aws
+++ b/aws
@@ -1115,7 +1115,7 @@ unshift @ARGV, $1 if $0 =~ /^(?:.*[\\\/])?(?:(?:ec2|pa|s3|sqs|sdb|rds)-?)?(.+?)(
     @meta{qw(1 assume AWS4 batch cmd0 content_length content_type credential_helper curl curl_options cut d default_curl_cipher delimiter dns_alias dump_xml
              exec expire_time fail h help http insecure insecure_signing insecure_aws insecureaws install json l limit_rate link max_keys
 	     max_time marker md5 metadata no_vhost netrc_machine parts prefix private progress public queue r region request requester retry role ruby quiet
-	     s3host sanity_check secrets_file set_acl sha1 silent simple sts_host t v verbose vv vvv wait xml yaml)} = undef;
+	     s3host sanity_check no_sanity_check secrets_file set_acl sha1 silent simple sts_host t v verbose vv vvv wait xml yaml)} = undef;
 
     my @awsrc = "";
     for (split(/(?:\#.*?(?=\n)|'(.*?)'|"((?:\\[\\\"]|.)*?)"|((?:\\.|\$.|[^\s\'\"\#])+))/s, load_file_silent("$home/.awsrc")))
@@ -1471,7 +1471,7 @@ for ([m => 60], [h => 60 * 60], [d => 24 * 60 * 60], [w => 7 * 24 * 60 * 60], [m
 
 # run a sanity check if $home/.awsrc doesn't exists, or if it was requested
 
-if (!-e "$home/.awsrc" || $sanity_check)
+if ( !$no_sanity_check && (!-e "$home/.awsrc" || $sanity_check))
 {
     if (!$silent)
     {


### PR DESCRIPTION
Add flag to disable sanity checks from the command line.

Makes it easier to use the script in a Continuous Delivery pipeline where adding dotfiles in the home dir is not recommended

