### PR TITLE
Exit with non zero (255) on non standard (or empty) s3 response

### DIFF
--- a/aws
+++ b/aws
@@ -1970,7 +1970,7 @@ if (!$cmd_data)
 		if ($r !~ /^<\?xml/)
 		{
 		    print $r;
-		    exit;
+		    exit 255;
 		}
 		$r =~ s/<\?xml.*?>\r?\s*//;
 		$result .= $r;


### PR DESCRIPTION
This can happen when there's something wrong calling the curl command, for example, the file doesn't exist. 

The exit code in this scenario should not be 0