### PR TITLE
Fix previous PR and fix AWS4 signing for md5 checks

### DIFF
--- a/aws
+++ b/aws
@@ -1970,7 +1970,7 @@ if (!$cmd_data)
 		if ($r !~ /^<\?xml/)
 		{
 		    print $r;
-		    exit 255;
+		    exit;
 		}
 		$r =~ s/<\?xml.*?>\r?\s*//;
 		$result .= $r;

--- a/aws
+++ b/aws
@@ -3031,7 +3031,6 @@ sub s3
 		$md5 = encode_base64(pack("H*", (split(" ", qx[md5sum @{[cq($file)]}]))[0]), "");
 	    }
 
-	    push @header, "Content-MD5: $md5";
 	    print STDERR "setting $header[$#header]\n" if $v;
 	}
     }


### PR DESCRIPTION
Example of curl commands with and without the header

With:
```
curl  -q -g -S --remote-time --retry 3 --verbose -s  --header "Expect: "  --header 'Content-MD5: kf7YD51cNTG2uV9b8BYAHA==' --request PUT --dump-header - --upload-file 'awsqa3.yaml' --location 'https://ecd-cf-templates.s3.amazonaws.com/test1?Expires=1561048671&AWSAccessKeyId=XXXXXXXXXXXXXXXXXXXX&Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
*   Trying 52.217.0.172...
* TCP_NODELAY set
* Connected to ecd-cf-templates.s3.amazonaws.com (52.217.0.172) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=Washington; L=Seattle; O=Amazon.com Inc.; CN=*.s3.amazonaws.com
*  start date: Nov  7 00:00:00 2018 GMT
*  expire date: Feb  7 12:00:00 2020 GMT
*  subjectAltName: host "ecd-cf-templates.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert Baltimore CA-2 G2
*  SSL certificate verify ok.
> PUT /test1?Expires=1561048671&AWSAccessKeyId=xxxxxxxxxxxxxxxxxxxx&Signature=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx HTTP/1.1
> Host: ecd-cf-templates.s3.amazonaws.com
> User-Agent: curl/7.54.0
> Accept: */*
> Content-MD5: kf7YD51cNTG2uV9b8BYAHA==
> Content-Length: 1022
>
* We are completely uploaded and fine
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< x-amz-id-2: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1kFe46/SCU5W9tm1cUzRF1N6Z2PMrLxsta4ozSDLtQ=
x-amz-id-2: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1kFe46/SCU5W9tm1cUzRF1N6Z2PMrLxsta4ozSDLtQ=
< x-amz-request-id: 9FXXXXXXXXXXXXX0
x-amz-request-id: 9F4XXXXXXXXXXXX0
< Date: Thu, 20 Jun 2019 16:37:27 GMT
Date: Thu, 20 Jun 2019 16:37:27 GMT
< ETag: "91fed80f9d5c3531b6b95f5bf016001c"
ETag: "91fed80f9d5c3531b6b95f5bf016001c"
< Content-Length: 0
Content-Length: 0
< Server: AmazonS3
Server: AmazonS3
```


Without:
```
curl  -q -g -S --remote-time --retry 3 --verbose -s  --header "Expect: "  --request PUT --dump-header - --upload-file 'awsqa3.yaml' --location 'https://ecd-cf-templates.s3.amazonaws.com/test1?Expires=1561048801&AWSAccessKeyId=XXXXXXXXXXXXXXXXXXXX&Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
*   Trying 52.216.236.43...
* TCP_NODELAY set
* Connected to ecd-cf-templates.s3.amazonaws.com (52.216.236.43) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=Washington; L=Seattle; O=Amazon.com Inc.; CN=*.s3.amazonaws.com
*  start date: Nov  7 00:00:00 2018 GMT
*  expire date: Feb  7 12:00:00 2020 GMT
*  subjectAltName: host "ecd-cf-templates.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert Baltimore CA-2 G2
*  SSL certificate verify ok.
> PUT /test1?Expires=1561048801&AWSAccessKeyId=XXXXXXXXXXXXXXXXXXXX&Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX HTTP/1.1
> Host: ecd-cf-templates.s3.amazonaws.com
> User-Agent: curl/7.54.0
> Accept: */*
> Content-Length: 1022
>
* We are completely uploaded and fine
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< x-amz-id-2: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXMdhnQz8cSLKUmJckqlrUSj/KcXyhXmo9jnRUeqH/LY=
x-amz-id-2: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXMdhnQz8cSLKUmJckqlrUSj/KcXyhXmo9jnRUeqH/LY=
< x-amz-request-id: XXXXXXXXXXXX47C1
x-amz-request-id: XXXXXXXXXXXXX7C1
< Date: Thu, 20 Jun 2019 16:39:36 GMT
Date: Thu, 20 Jun 2019 16:39:36 GMT
< ETag: "91fed80f9d5c3531b6b95f5bf016001c"
ETag: "91fed80f9d5c3531b6b95f5bf016001c"
< Content-Length: 0
Content-Length: 0
< Server: AmazonS3
Server: AmazonS3
```